### PR TITLE
Front

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -2406,9 +2406,9 @@
       "integrity": "sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug=="
     },
     "@types/react": {
-      "version": "17.0.5",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.5.tgz",
-      "integrity": "sha512-bj4biDB9ZJmGAYTWSKJly6bMr4BLUiBrx9ujiJEoP9XIDY9CTaPGxE5QWN/1WjpPLzYF7/jRNnV2nNxNe970sw==",
+      "version": "17.0.8",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.8.tgz",
+      "integrity": "sha512-3sx4c0PbXujrYAKwXxNONXUtRp9C+hE2di0IuxFyf5BELD+B+AXL8G7QrmSKhVwKZDbv0igiAjQAMhXj8Yg3aw==",
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",

--- a/front/package.json
+++ b/front/package.json
@@ -55,7 +55,7 @@
   "devDependencies": {
     "@types/faker": "^5.5.4",
     "@types/node": "^12.20.12",
-    "@types/react": "^17.0.5",
+    "@types/react": "^17.0.8",
     "@types/react-dom": "^17.0.3",
     "@types/react-redux": "^7.1.16",
     "@types/react-router-dom": "^5.1.7",

--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -1,15 +1,29 @@
 import React from 'react';
-import { BrowserRouter, Redirect, Route, Switch } from 'react-router-dom';
-import { Explore, Home, Login, SignUp } from './components';
+import { BrowserRouter, Redirect, Switch } from 'react-router-dom';
+import { Explore, Home, SignUp } from './components';
+import { LoginContainer } from './containers';
+import AuthRoute from './AuthRoute';
 
 function App() {
   return (
     <BrowserRouter>
       <Switch>
-        <Route path="/" exact component={Home} />
-        <Route path="/login" component={Login} />
-        <Route path="/signup" component={SignUp} />
-        <Route path="/explore" component={Explore} />
+        <AuthRoute authenticated="loggedIn" path="/" component={Home} exact />
+        <AuthRoute
+          authenticated="notLoggedIn"
+          path="/login"
+          component={LoginContainer}
+        />
+        <AuthRoute
+          authenticated="notLoggedIn"
+          path="/signup"
+          component={SignUp}
+        />
+        <AuthRoute
+          authenticated="loggedIn"
+          path="/explore"
+          component={Explore}
+        />
         <Redirect path="*" to="/" />
       </Switch>
     </BrowserRouter>

--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -8,21 +8,21 @@ function App() {
   return (
     <BrowserRouter>
       <Switch>
-        <AuthRoute authenticated="loggedIn" path="/" component={Home} exact />
+        <AuthRoute authenticated="loggedIn" path="/" Component={Home} exact />
         <AuthRoute
           authenticated="notLoggedIn"
           path="/login"
-          component={LoginContainer}
+          Component={LoginContainer}
         />
         <AuthRoute
           authenticated="notLoggedIn"
           path="/signup"
-          component={SignUp}
+          Component={SignUp}
         />
         <AuthRoute
           authenticated="loggedIn"
           path="/explore"
-          component={Explore}
+          Component={Explore}
         />
         <Redirect path="*" to="/" />
       </Switch>

--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { BrowserRouter, Redirect, Switch } from 'react-router-dom';
+import { BrowserRouter, Redirect, Route, Switch } from 'react-router-dom';
 import { Explore, Home, SignUp } from './components';
 import { LoginContainer } from './containers';
 import AuthRoute from './AuthRoute';
@@ -9,11 +9,7 @@ function App() {
     <BrowserRouter>
       <Switch>
         <AuthRoute authenticated="loggedIn" path="/" Component={Home} exact />
-        <AuthRoute
-          authenticated="notLoggedIn"
-          path="/login"
-          Component={LoginContainer}
-        />
+        <Route path="/login" component={LoginContainer} />
         <AuthRoute
           authenticated="notLoggedIn"
           path="/signup"

--- a/front/src/AuthRoute.tsx
+++ b/front/src/AuthRoute.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { Redirect, Route } from 'react-router-dom';
+import { useSelector } from 'react-redux';
+import { RootState } from './store';
+
+interface props {
+  authenticated: 'loggedIn' | 'notLoggedIn';
+  path: string;
+  component: React.ComponentType<any>;
+  [rest: string]: any;
+}
+
+const AuthRoute = ({ authenticated, path, component, ...rest }: props) => {
+  const { user } = useSelector((state: RootState) => state.auth);
+  const isLoggedIn = user.email && user.nickname;
+  const Component = <Route {...rest} path={path} component={component} />;
+
+  switch (authenticated) {
+    case 'loggedIn':
+      if (!isLoggedIn) return <Redirect to="/login" />;
+      else return Component;
+
+    case 'notLoggedIn':
+      if (isLoggedIn) return <Redirect to="/" />;
+      else return Component;
+  }
+};
+
+export default AuthRoute;

--- a/front/src/AuthRoute.tsx
+++ b/front/src/AuthRoute.tsx
@@ -11,7 +11,7 @@ interface props {
 }
 
 const AuthRoute = ({ authenticated, path, Component, ...rest }: props) => {
-  const { user } = useSelector((state: RootState) => state.auth);
+  const user = useSelector((state: RootState) => state.auth.user);
   const isLoggedIn = user.email && user.nickname;
 
   switch (authenticated) {

--- a/front/src/AuthRoute.tsx
+++ b/front/src/AuthRoute.tsx
@@ -6,23 +6,30 @@ import { RootState } from './store';
 interface props {
   authenticated: 'loggedIn' | 'notLoggedIn';
   path: string;
-  component: React.ComponentType<any>;
+  Component: React.ComponentType<any>;
   [rest: string]: any;
 }
 
-const AuthRoute = ({ authenticated, path, component, ...rest }: props) => {
+const AuthRoute = ({ authenticated, path, Component, ...rest }: props) => {
   const { user } = useSelector((state: RootState) => state.auth);
   const isLoggedIn = user.email && user.nickname;
-  const Component = <Route {...rest} path={path} component={component} />;
 
   switch (authenticated) {
     case 'loggedIn':
       if (!isLoggedIn) return <Redirect to="/login" />;
-      else return Component;
+      else
+        return (
+          <Route
+            {...rest}
+            path={path}
+            component={() => <Component user={user} />}
+          />
+        );
 
     case 'notLoggedIn':
       if (isLoggedIn) return <Redirect to="/" />;
-      else return Component;
+      else
+        return <Route {...rest} path={path} component={() => <Component />} />;
   }
 };
 

--- a/front/src/components/Auth/Login.tsx
+++ b/front/src/components/Auth/Login.tsx
@@ -1,25 +1,23 @@
-import React, { useCallback } from 'react';
+import React from 'react';
 import { StyledLink, StyledLogin, Wrapper } from './styles';
 import logo from '../../lib/assets/InstagramLogo.png';
 import useInput from '../../lib/hooks/useInput';
 
-const Login = () => {
+interface props {
+  onSubmitLogin: (
+    e: React.FormEvent<HTMLFormElement>
+  ) => (email: string, password: string) => void;
+}
+
+const Login = ({ onSubmitLogin }: props) => {
   const [email, onChangeEmail] = useInput('');
   const [password, onChangePassword] = useInput('');
-
-  const onSubmitLogin = useCallback(
-    (e: React.FormEvent<HTMLFormElement>): void => {
-      e.preventDefault();
-      console.log(email, password);
-    },
-    [email, password]
-  );
 
   return (
     <Wrapper>
       <StyledLogin>
         <img src={logo} alt="logo" />
-        <form onSubmit={onSubmitLogin}>
+        <form onSubmit={(e) => onSubmitLogin(e)(email, password)}>
           <input
             type="email"
             value={email}
@@ -34,7 +32,7 @@ const Login = () => {
           />
           <button type="submit">로그인</button>
         </form>
-        <span>
+        <span className="link">
           계정이 없으신가요? <StyledLink to="/signup">가입하기</StyledLink>
         </span>
       </StyledLogin>

--- a/front/src/components/Auth/SignUp.tsx
+++ b/front/src/components/Auth/SignUp.tsx
@@ -7,6 +7,7 @@ import { RootState } from '../../store';
 import { useHistory } from 'react-router-dom';
 import { AiFillEye, AiFillEyeInvisible } from 'react-icons/all';
 import { validateSignUpData } from './validation';
+import { SignUpData } from '../../store/auth/types';
 
 const SignUp = () => {
   const dispatch = useDispatch();
@@ -126,7 +127,7 @@ const SignUp = () => {
           </button>
         </form>
 
-        <span className="go-login">
+        <span className="link">
           계정이 있으신가요? <StyledLink to="/login">로그인</StyledLink>
         </span>
       </StyledLogin>

--- a/front/src/components/Auth/styles.ts
+++ b/front/src/components/Auth/styles.ts
@@ -110,7 +110,7 @@ export const StyledLogin = styled.div`
     }
   }
 
-  span.go-login {
+  span.link {
     margin: 25px 0;
     color: black;
   }

--- a/front/src/components/Auth/validation.ts
+++ b/front/src/components/Auth/validation.ts
@@ -1,3 +1,5 @@
+import { SignUpData } from '../../store/auth/types';
+
 const regexEmail: RegExp = /^[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*\.[a-zA-Z]{2,3}$/i;
 const regexPassword: RegExp = /^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]+$/;
 const regexNickname: RegExp = /^([가-힣ㄱ-ㅎa-zA-Z0-9._])+$/;

--- a/front/src/components/Home/index.tsx
+++ b/front/src/components/Home/index.tsx
@@ -3,8 +3,13 @@ import faker from 'faker';
 import AppLayout from '../common/AppLayout';
 import { Wrapper } from './styles';
 import Card from './Card';
+import { UserInfo } from '../../store/auth/types';
 
-const Home = () => {
+interface props {
+  user: UserInfo;
+}
+
+const Home = ({ user }: props) => {
   return (
     <AppLayout>
       <Wrapper>
@@ -18,7 +23,7 @@ const Home = () => {
           <div className="info">
             <div className="profile">
               <img src={faker.image.avatar()} alt={faker.image.avatar()} />
-              <span>{faker.name.findName()}</span>
+              <span>{user.nickname}</span>
             </div>
 
             <div className="follow">

--- a/front/src/components/common/AppLayout.tsx
+++ b/front/src/components/common/AppLayout.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
+import { NavBarContainer } from '../../containers';
 import { StyledAppLayout } from './styles';
-import NavBar from './NavBar';
 
 interface props {
   children: JSX.Element | JSX.Element[];
@@ -9,7 +9,7 @@ interface props {
 const AppLayout = ({ children }: props) => {
   return (
     <StyledAppLayout>
-      <NavBar />
+      <NavBarContainer />
       <div className="box">
         <div className="children">{children}</div>
       </div>

--- a/front/src/components/common/NavBar.tsx
+++ b/front/src/components/common/NavBar.tsx
@@ -1,5 +1,7 @@
-import React from 'react';
-import { StyledNavBar } from './styles';
+import React, { useState } from 'react';
+import { StyledNavBar, StyledMenu } from './styles';
+import faker from 'faker';
+import { BsGearWide, CgProfile } from 'react-icons/all';
 
 interface props {
   user: string | null;
@@ -7,14 +9,35 @@ interface props {
 }
 
 const NavBar = ({ user, onClickLogout }: props) => {
+  const [openProfileMenu, setOpenProfileMenu] = useState<boolean>(false);
+
   return (
     <StyledNavBar>
       <div className="content">
         <div>instagram</div>
+
         <div>검색</div>
-        <div>
-          <span>{user}</span>
-          <button onClick={onClickLogout}>로그아웃</button>
+
+        <div className="profile">
+          <StyledMenu>
+            <img
+              src={faker.image.avatar()}
+              alt={faker.image.avatar()}
+              onClick={() => setOpenProfileMenu((prev) => (prev = !prev))}
+            />
+
+            <div className={`menu${openProfileMenu ? ' opened' : ' closed'}`}>
+              <button>
+                <CgProfile />
+                프로필
+              </button>
+              <button>
+                <BsGearWide />
+                설정
+              </button>
+              <button onClick={onClickLogout}>로그아웃</button>
+            </div>
+          </StyledMenu>
         </div>
       </div>
     </StyledNavBar>

--- a/front/src/components/common/NavBar.tsx
+++ b/front/src/components/common/NavBar.tsx
@@ -1,13 +1,21 @@
 import React from 'react';
 import { StyledNavBar } from './styles';
 
-const NavBar = () => {
+interface props {
+  user: string | null;
+  onClickLogout: () => void;
+}
+
+const NavBar = ({ user, onClickLogout }: props) => {
   return (
     <StyledNavBar>
       <div className="content">
         <div>instagram</div>
         <div>검색</div>
-        <div>icon</div>
+        <div>
+          <span>{user}</span>
+          <button onClick={onClickLogout}>로그아웃</button>
+        </div>
       </div>
     </StyledNavBar>
   );

--- a/front/src/components/common/styles.ts
+++ b/front/src/components/common/styles.ts
@@ -23,6 +23,11 @@ export const StyledNavBar = styled.div`
     ${media.desktop} {
       width: 100%;
     }
+
+    .profile {
+      display: flex;
+      align-items: center;
+    }
   }
 `;
 
@@ -35,5 +40,80 @@ export const StyledAppLayout = styled.div`
       display: flex;
       justify-content: center;
     }
+  }
+`;
+
+export const StyledMenu = styled.div`
+  position: relative;
+  font-size: 14px;
+
+  img {
+    width: 22px;
+    height: 22px;
+    border-radius: 70%;
+    :hover {
+      cursor: pointer;
+    }
+  }
+
+  .opened {
+    transform: translate(0, 35px);
+    opacity: 1;
+    visibility: visible;
+  }
+  .closed {
+    transform: translate(0, 0);
+    opacity: 0;
+    visibility: hidden;
+  }
+
+  .menu {
+    position: absolute;
+    top: 0;
+    right: -20px;
+
+    display: flex;
+    flex-direction: column;
+
+    background-color: white;
+    border-radius: 5px;
+    box-shadow: 0 0 8px ${({ theme }) => theme.border.gray};
+
+    transition: all 0.3s ease;
+
+    button {
+      display: flex;
+      align-items: center;
+
+      width: 198px;
+      height: 44px;
+      padding: 8px 16px;
+      text-align: left;
+
+      svg {
+        width: 16px;
+        height: 16px;
+        margin-right: 12px;
+      }
+
+      :hover {
+        background-color: ${({ theme }) => theme.background.gray};
+      }
+    }
+
+    button:nth-last-child(1) {
+      border-top: 1px solid ${({ theme }) => theme.border.gray};
+    }
+  }
+
+  .menu::after {
+    content: '';
+    position: absolute;
+    bottom: 100%;
+    right: 26px;
+    margin-left: -5px;
+    border-width: 5px;
+    border-style: solid;
+    border-color: transparent transparent white transparent;
   }
 `;

--- a/front/src/containers/Auth/LoginContainer.tsx
+++ b/front/src/containers/Auth/LoginContainer.tsx
@@ -12,7 +12,7 @@ import { Login } from '../../components';
 const LoginContainer = () => {
   const dispatch = useDispatch();
   const { error } = useSelector((state: RootState) => state.auth.login);
-  const { user } = useSelector((state: RootState) => state.auth);
+  const user = useSelector((state: RootState) => state.auth.user);
 
   const history = useHistory();
 

--- a/front/src/containers/Auth/LoginContainer.tsx
+++ b/front/src/containers/Auth/LoginContainer.tsx
@@ -1,0 +1,37 @@
+import React, { useCallback, useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { RootState } from '../../store';
+import { loginAsync } from '../../store/auth/actions';
+import { useHistory } from 'react-router-dom';
+import { Login } from '../../components';
+
+const LoginContainer = () => {
+  const dispatch = useDispatch();
+  const { error } = useSelector((state: RootState) => state.auth.login);
+  const { user } = useSelector((state: RootState) => state.auth);
+
+  const history = useHistory();
+
+  const onSubmitLogin = useCallback(
+    (e: React.FormEvent<HTMLFormElement>) => (
+      email: string,
+      password: string
+    ): void => {
+      e.preventDefault();
+      dispatch(loginAsync.request({ email, password }));
+    },
+    [dispatch]
+  );
+
+  useEffect(() => {
+    if (user.email !== null && user.nickname !== null) {
+      history.push('/');
+    } else if (error) {
+      alert(error.message);
+    }
+  }, [history, user, error]);
+
+  return <Login onSubmitLogin={onSubmitLogin} />;
+};
+
+export default LoginContainer;

--- a/front/src/containers/Auth/LoginContainer.tsx
+++ b/front/src/containers/Auth/LoginContainer.tsx
@@ -23,23 +23,23 @@ const LoginContainer = () => {
     ): void => {
       e.preventDefault();
       dispatch(loginAsync.request({ email, password }));
-
-      const timer = setInterval(() => {
-        dispatch(silentRefreshAsync.request());
-      }, 1000 * 60 * 59);
-
-      dispatch(setAutoLogin({ timer }));
     },
     [dispatch]
   );
 
   useEffect(() => {
     if (user.email !== null && user.nickname !== null) {
+      const timer = setInterval(() => {
+        dispatch(silentRefreshAsync.request());
+      }, 1000 * 60 * 59);
+
+      dispatch(setAutoLogin({ timer }));
+
       history.push('/');
     } else if (error) {
       alert(error.message);
     }
-  }, [history, user, error]);
+  }, [dispatch, history, user, error]);
 
   return <Login onSubmitLogin={onSubmitLogin} />;
 };

--- a/front/src/containers/Auth/LoginContainer.tsx
+++ b/front/src/containers/Auth/LoginContainer.tsx
@@ -1,7 +1,11 @@
 import React, { useCallback, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { RootState } from '../../store';
-import { loginAsync } from '../../store/auth/actions';
+import {
+  loginAsync,
+  setAutoLogin,
+  silentRefreshAsync,
+} from '../../store/auth/actions';
 import { useHistory } from 'react-router-dom';
 import { Login } from '../../components';
 
@@ -19,6 +23,12 @@ const LoginContainer = () => {
     ): void => {
       e.preventDefault();
       dispatch(loginAsync.request({ email, password }));
+
+      const timer = setInterval(() => {
+        dispatch(silentRefreshAsync.request());
+      }, 1000 * 60 * 59);
+
+      dispatch(setAutoLogin({ timer }));
     },
     [dispatch]
   );

--- a/front/src/containers/common/NavBarContainer.tsx
+++ b/front/src/containers/common/NavBarContainer.tsx
@@ -1,0 +1,19 @@
+import React, { useCallback } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { RootState } from '../../store';
+import NavBar from '../../components/common/NavBar';
+import { clearAutoLogin, logoutAsync } from '../../store/auth/actions';
+
+const NavBarContainer = () => {
+  const dispatch = useDispatch();
+  const { nickname } = useSelector((state: RootState) => state.auth.user);
+
+  const onClickLogout = useCallback((): void => {
+    dispatch(logoutAsync.request());
+    dispatch(clearAutoLogin());
+  }, [dispatch]);
+
+  return <NavBar user={nickname} onClickLogout={onClickLogout} />;
+};
+
+export default NavBarContainer;

--- a/front/src/containers/index.tsx
+++ b/front/src/containers/index.tsx
@@ -1,1 +1,2 @@
 export { default as LoginContainer } from './Auth/LoginContainer';
+export { default as NavBarContainer } from './common/NavBarContainer';

--- a/front/src/containers/index.tsx
+++ b/front/src/containers/index.tsx
@@ -1,0 +1,1 @@
+export { default as LoginContainer } from './Auth/LoginContainer';

--- a/front/src/store/auth/actions.ts
+++ b/front/src/store/auth/actions.ts
@@ -1,4 +1,4 @@
-import { createAsyncAction } from 'typesafe-actions';
+import { createAction, createAsyncAction } from 'typesafe-actions';
 import { LoginData, SignUpData } from './types';
 
 export const SIGN_UP = 'auth/SIGN_UP';
@@ -8,6 +8,17 @@ export const SIGN_UP_ERROR = 'auth/SIGN_UP_ERROR';
 export const LOGIN = 'auth/LOGIN';
 export const LOGIN_SUCCESS = 'auth/LOGIN_SUCCESS';
 export const LOGIN_ERROR = 'auth/LOGIN_ERROR';
+
+export const SILENT_REFRESH = 'auth/SILENT_REFRESH';
+export const SILENT_REFRESH_SUCCESS = 'auth/SILENT_REFRESH_SUCCESS';
+export const SILENT_REFRESH_ERROR = 'auth/SILENT_REFRESH_ERROR';
+
+export const LOGOUT = 'auth/LOGOUT';
+export const LOGOUT_SUCCESS = 'auth/LOGOUT_SUCCESS';
+export const LOGOUT_ERROR = 'auth/LOGOUT_ERROR';
+
+export const SET_AUTO_LOGIN = 'auth/SET_AUTO_LOGIN';
+export const CLEAR_AUTO_LOGIN = 'auth/CLEAR_AUTO_LOGIN';
 
 export const signUpAsync = createAsyncAction(
   SIGN_UP,
@@ -20,3 +31,21 @@ export const loginAsync = createAsyncAction(LOGIN, LOGIN_SUCCESS, LOGIN_ERROR)<
   ResponseData,
   ResponseData
 >();
+
+export const silentRefreshAsync = createAsyncAction(
+  SILENT_REFRESH,
+  SILENT_REFRESH_SUCCESS,
+  SILENT_REFRESH_ERROR
+)<undefined, ResponseData, ResponseData>();
+
+export const logoutAsync = createAsyncAction(
+  LOGOUT,
+  LOGOUT_SUCCESS,
+  LOGOUT_ERROR
+)<undefined, ResponseData, ResponseData>();
+
+export const setAutoLogin = createAction(SET_AUTO_LOGIN, ({ timer }) => ({
+  timer,
+}))();
+
+export const clearAutoLogin = createAction(CLEAR_AUTO_LOGIN)();

--- a/front/src/store/auth/actions.ts
+++ b/front/src/store/auth/actions.ts
@@ -1,11 +1,22 @@
 import { createAsyncAction } from 'typesafe-actions';
+import { LoginData, SignUpData } from './types';
 
 export const SIGN_UP = 'auth/SIGN_UP';
 export const SIGN_UP_SUCCESS = 'auth/SIGN_UP_SUCCESS';
 export const SIGN_UP_ERROR = 'auth/SIGN_UP_ERROR';
+
+export const LOGIN = 'auth/LOGIN';
+export const LOGIN_SUCCESS = 'auth/LOGIN_SUCCESS';
+export const LOGIN_ERROR = 'auth/LOGIN_ERROR';
 
 export const signUpAsync = createAsyncAction(
   SIGN_UP,
   SIGN_UP_SUCCESS,
   SIGN_UP_ERROR
 )<SignUpData, ResponseData, ResponseData>();
+
+export const loginAsync = createAsyncAction(LOGIN, LOGIN_SUCCESS, LOGIN_ERROR)<
+  LoginData,
+  ResponseData,
+  ResponseData
+>();

--- a/front/src/store/auth/reducers.ts
+++ b/front/src/store/auth/reducers.ts
@@ -3,7 +3,12 @@ import { asyncState } from '../../lib/reducerUtils';
 import { AuthAction, AuthState } from './types';
 
 const initialState: AuthState = {
+  user: {
+    email: null,
+    nickname: null,
+  },
   signup: asyncState.initial(),
+  login: asyncState.initial(),
 };
 
 const auth = (state: AuthState = initialState, action: AuthAction) =>
@@ -18,6 +23,16 @@ const auth = (state: AuthState = initialState, action: AuthAction) =>
       case 'auth/SIGN_UP_ERROR':
         draft.signup = asyncState.error(action.payload);
         break;
+
+      case 'auth/LOGIN':
+        draft.login = asyncState.loading();
+        break;
+      case 'auth/LOGIN_SUCCESS':
+        draft.login = asyncState.success(null);
+        draft.user = action.payload.data.info;
+        break;
+      case 'auth/LOGIN_ERROR':
+        draft.login = asyncState.error(action.payload);
     }
   });
 

--- a/front/src/store/auth/reducers.ts
+++ b/front/src/store/auth/reducers.ts
@@ -9,6 +9,9 @@ const initialState: AuthState = {
   },
   signup: asyncState.initial(),
   login: asyncState.initial(),
+  silentRefresh: asyncState.initial(),
+  logout: asyncState.initial(),
+  timer: null,
 };
 
 const auth = (state: AuthState = initialState, action: AuthAction) =>
@@ -33,6 +36,37 @@ const auth = (state: AuthState = initialState, action: AuthAction) =>
         break;
       case 'auth/LOGIN_ERROR':
         draft.login = asyncState.error(action.payload);
+        break;
+
+      case 'auth/SILENT_REFRESH':
+        draft.silentRefresh = asyncState.loading();
+        break;
+      case 'auth/SILENT_REFRESH_SUCCESS':
+        draft.silentRefresh = asyncState.success(null);
+        break;
+      case 'auth/SILENT_REFRESH_ERROR':
+        draft.silentRefresh = asyncState.error(action.payload);
+        break;
+
+      case 'auth/LOGOUT':
+        draft.logout = asyncState.loading();
+        break;
+      case 'auth/LOGOUT_SUCCESS':
+        draft.logout = asyncState.success(null);
+        draft.user.email = null;
+        draft.user.nickname = null;
+        break;
+      case 'auth/LOGOUT_ERROR':
+        draft.logout = asyncState.error(action.payload);
+        break;
+
+      case 'auth/SET_AUTO_LOGIN':
+        draft.timer = action.payload.timer;
+        break;
+      case 'auth/CLEAR_AUTO_LOGIN':
+        clearInterval(draft.timer as NodeJS.Timeout);
+        draft.timer = null;
+        break;
     }
   });
 

--- a/front/src/store/auth/sagas.ts
+++ b/front/src/store/auth/sagas.ts
@@ -1,6 +1,15 @@
 import axios, { AxiosResponse } from 'axios';
 import { call, put, takeEvery } from 'redux-saga/effects';
-import { LOGIN, loginAsync, SIGN_UP, signUpAsync } from './actions';
+import {
+  LOGIN,
+  loginAsync,
+  logoutAsync,
+  SIGN_UP,
+  signUpAsync,
+  SILENT_REFRESH,
+  silentRefreshAsync,
+  LOGOUT,
+} from './actions';
 import { LoginData, SignUpData } from './types';
 
 const signUpAPI = (data: SignUpData) => axios.post('/user', data);
@@ -28,7 +37,35 @@ function* loginSaga(action: ReturnType<typeof loginAsync.request>) {
   }
 }
 
+const silentRefreshAPI = () => axios.get('/user/silent-refresh');
+
+function* silentRefreshSaga() {
+  try {
+    const response: AxiosResponse = yield call(silentRefreshAPI);
+    axios.defaults.headers.common[
+      'x-access-token'
+    ] = `${response.data.data.token}`;
+    yield put(silentRefreshAsync.success(response.data));
+  } catch (e) {
+    yield put(silentRefreshAsync.failure(e.response.data));
+  }
+}
+
+const logoutAPI = () => axios.get('/user/logout');
+
+function* logoutSaga() {
+  try {
+    const response: AxiosResponse = yield call(logoutAPI);
+    delete axios.defaults.headers.common['x-access-token'];
+    yield put(logoutAsync.success(response.data));
+  } catch (e) {
+    yield put(logoutAsync.failure(e.response.data));
+  }
+}
+
 export function* authSaga() {
   yield takeEvery(SIGN_UP, signUpSaga);
   yield takeEvery(LOGIN, loginSaga);
+  yield takeEvery(SILENT_REFRESH, silentRefreshSaga);
+  yield takeEvery(LOGOUT, logoutSaga);
 }

--- a/front/src/store/auth/sagas.ts
+++ b/front/src/store/auth/sagas.ts
@@ -1,6 +1,7 @@
 import axios, { AxiosResponse } from 'axios';
 import { call, put, takeEvery } from 'redux-saga/effects';
-import { SIGN_UP, signUpAsync } from './actions';
+import { LOGIN, loginAsync, SIGN_UP, signUpAsync } from './actions';
+import { LoginData, SignUpData } from './types';
 
 const signUpAPI = (data: SignUpData) => axios.post('/user', data);
 
@@ -13,6 +14,21 @@ function* signUpSaga(action: ReturnType<typeof signUpAsync.request>) {
   }
 }
 
+const loginAPI = (data: LoginData) => axios.post('/user/login', data);
+
+function* loginSaga(action: ReturnType<typeof loginAsync.request>) {
+  try {
+    const response: AxiosResponse = yield call(loginAPI, action.payload);
+    axios.defaults.headers.common[
+      'x-access-token'
+    ] = `${response.data.data.token}`;
+    yield put(loginAsync.success(response.data));
+  } catch (e) {
+    yield put(loginAsync.failure(e.response.data));
+  }
+}
+
 export function* authSaga() {
   yield takeEvery(SIGN_UP, signUpSaga);
+  yield takeEvery(LOGIN, loginSaga);
 }

--- a/front/src/store/auth/types.ts
+++ b/front/src/store/auth/types.ts
@@ -1,9 +1,27 @@
 import { AsyncState } from '../../lib/reducerUtils';
 import { ActionType } from 'typesafe-actions';
-import { signUpAsync } from './actions';
+import { loginAsync, signUpAsync } from './actions';
 
 export type AuthState = {
+  user: UserInfo;
   signup: AsyncState<ResponseData, ResponseData>;
+  login: AsyncState<ResponseData, ResponseData>;
 };
 
-export type AuthAction = ActionType<typeof signUpAsync>;
+export type AuthAction = ActionType<typeof signUpAsync | typeof loginAsync>;
+
+export interface SignUpData {
+  email: string | undefined;
+  password: string | undefined;
+  nickname: string | undefined;
+}
+
+export interface LoginData {
+  email: string | undefined;
+  password: string | undefined;
+}
+
+export interface UserInfo {
+  email: string | null;
+  nickname: string | null;
+}

--- a/front/src/store/auth/types.ts
+++ b/front/src/store/auth/types.ts
@@ -1,14 +1,31 @@
 import { AsyncState } from '../../lib/reducerUtils';
 import { ActionType } from 'typesafe-actions';
-import { loginAsync, signUpAsync } from './actions';
+import {
+  clearAutoLogin,
+  loginAsync,
+  logoutAsync,
+  setAutoLogin,
+  signUpAsync,
+  silentRefreshAsync,
+} from './actions';
 
 export type AuthState = {
   user: UserInfo;
   signup: AsyncState<ResponseData, ResponseData>;
   login: AsyncState<ResponseData, ResponseData>;
+  silentRefresh: AsyncState<ResponseData, ResponseData>;
+  logout: AsyncState<ResponseData, ResponseData>;
+  timer: NodeJS.Timeout | null;
 };
 
-export type AuthAction = ActionType<typeof signUpAsync | typeof loginAsync>;
+export type AuthAction = ActionType<
+  | typeof signUpAsync
+  | typeof loginAsync
+  | typeof silentRefreshAsync
+  | typeof logoutAsync
+  | typeof setAutoLogin
+  | typeof clearAutoLogin
+>;
 
 export interface SignUpData {
   email: string | undefined;

--- a/front/src/types/index.d.ts
+++ b/front/src/types/index.d.ts
@@ -1,9 +1,3 @@
-declare interface SignUpData {
-  email: string | undefined;
-  password: string | undefined;
-  nickname: string | undefined;
-}
-
 declare interface ResponseData {
   success: boolean;
   message: string;


### PR DESCRIPTION
### 1. 로그인

로그인 로직은 #8 pull request의 방식과 같음

신경 쓴 점은 **자동 로그인 연장**인데, 다음과 같이 구현했다.

- 서버로부터 로그인성공 response를 받으면
- login page의 container에서 useEffect를 통해 성공 여부를 감지해
- 59분마다 로그인 연장 request를 보내는 action을 dispatch하는 타이머를 만들어서
- 자동 로그인 action에 timer를 넣어서 store에 저장한다!

타이머 함수를 가지고 있어야 로그아웃했을 때 함수를 통해 타이머를 날릴 수 있기 때문에 이와 같이 구현했다.

로그인 페이지만 AuthRoute를 통해 라우팅 되지 않는다는 점이 껄끄럽지만... 다르게 해결할 방법을 찾지못했다.

login saga 내에서 처리하면 best인데

```jsx
const timer = setInterval(() => {
  yield put(silentRefreshAsync.request()); // error
}, 5000);
```

위와 같이 action을 dispatch 하지 못해서 page container에서 처리하게 되었다 ㅠㅠ

### 2. redux & useSelector

```jsx
const { user } = useSelector((state: RootState) => state.auth);
```

위와 같이 구조 분해 할당한 상태를 props로 받는 component는...? auth 상태 내의 다른 상태가 바뀌어도 rerendering이 일어난다

```jsx
const user = useSelector((state: RootState) => state.auth.user);
```

이렇게 바꿔주면 불필요한 rerendering이 일어나지 않는다!

참고자료:
[🍪 프론트에서 안전하게 로그인 처리하기 (ft. React) - yaytomato](https://velog.io/@yaytomato/%ED%94%84%EB%A1%A0%ED%8A%B8%EC%97%90%EC%84%9C-%EC%95%88%EC%A0%84%ED%95%98%EA%B2%8C-%EB%A1%9C%EA%B7%B8%EC%9D%B8-%EC%B2%98%EB%A6%AC%ED%95%98%EA%B8%B0)